### PR TITLE
Release 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ An `.envrc` file is created during installation. If you have [direnv](https://di
 direnv allow
 ```
 
-This sets the `COMPOSER` env var and sources the shell helpers, so `composer`, `drush`, `php` and `phpunit` all delegate to DDEV automatically when you're in the project directory.
+This sets the `COMPOSER` env var on the host so that running `composer` directly on the host uses the overlay. Note that direnv cannot export shell functions, so you still need the shell helpers above for `composer`, `drush`, `php` and `phpunit` delegation.
 
 ## Command reference
 

--- a/drupal-dev/envrc
+++ b/drupal-dev/envrc
@@ -1,3 +1,2 @@
 # #ddev-generated
 export COMPOSER=composer.local.json
-source .ddev/drupal-dev/shell-helpers.sh

--- a/drupal-dev/shell-helpers.sh
+++ b/drupal-dev/shell-helpers.sh
@@ -24,7 +24,7 @@ _ddev_delegate() {
   fi
 }
 
-composer() { _ddev_delegate composer "$@"; }
-drush()    { _ddev_delegate drush "$@"; }
-php()      { _ddev_delegate php "$@"; }
-phpunit()  { _ddev_delegate phpunit "$@"; }
+function composer { _ddev_delegate composer "$@"; }
+function drush    { _ddev_delegate drush "$@"; }
+function php      { _ddev_delegate php "$@"; }
+function phpunit  { _ddev_delegate phpunit "$@"; }

--- a/install.yaml
+++ b/install.yaml
@@ -38,7 +38,7 @@ post_install_actions:
     printf '\n'
     printf "    \033[36msource \"$(cd .. && pwd)/.ddev/drupal-dev/shell-helpers.sh\"\033[0m\n"
     printf '\n'
-    printf '  Or if you use \033[1mdirenv\033[0m, run: \033[36mdirenv allow\033[0m\n'
+    printf '  If you use \033[1mdirenv\033[0m, also run: \033[36mdirenv allow\033[0m\n'
     printf '\n'
 
 removal_actions:


### PR DESCRIPTION
## Summary

- Fix shell helpers for zsh alias compatibility (use `function` keyword).
- Remove `source shell-helpers.sh` from `.envrc` (direnv cannot export shell functions).
- Clarify direnv docs in README and post-install message.