### PR TITLE
fix: Use git.drupalcode.org for SSH clone URL in add-module

### DIFF
--- a/commands/web/add-module
+++ b/commands/web/add-module
@@ -54,7 +54,7 @@ if [ -z "$MODULE_DIR" ]; then
   MODULE_DIR="modules/contrib/$MODULE_NAME"
 fi
 DRUPAL_GIT_HTTPS="https://git.drupalcode.org/project/$MODULE_NAME.git"
-DRUPAL_GIT_SSH="git@git.drupal.org:project/$MODULE_NAME.git"
+DRUPAL_GIT_SSH="git@git.drupalcode.org:project/$MODULE_NAME.git"
 
 if [ -d "$MODULE_DIR" ]; then
   if [ ! -d "$MODULE_DIR/.git" ]; then


### PR DESCRIPTION
- SSH URL was pointing at `git.drupal.org` which does not host the project repos; align it with the HTTPS URL on the preceding line.