### PR TITLE
fix: Run module management commands on the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ ddev composer install
 Use `ddev add-module` to clone a contrib module for development:
 
 ```bash
-ddev auth ssh                   # forward SSH keys (needed once per session)
 ddev add-module token
 ddev add-module token 2.0.x     # specific branch
 ddev add-module --https token   # or use HTTPS (no push access)
 ```
+
+The clone runs on your host, so it uses your host SSH keys directly; no `ddev auth ssh` needed.
 
 This clones the module into `modules/contrib/`, registers it as a path repository in `composer.local.json`, and runs `composer require`, all in one step.
 

--- a/commands/host/add-module
+++ b/commands/host/add-module
@@ -4,8 +4,6 @@
 ## Description: Clone a contrib module for development
 ## Usage: add-module [--https] <module_name> [branch]
 ## Example: "ddev add-module token" or "ddev add-module token 2.0.x"
-## ExecRaw: true
-## MutagenSync: true
 
 set -e
 
@@ -28,7 +26,7 @@ if [ $# -eq 0 ]; then
   echo "Options:"
   echo "  --https    Clone via HTTPS instead of SSH (read-only, no push access)"
   echo ""
-  echo "SSH cloning requires 'ddev auth ssh' to forward your SSH keys."
+  echo "SSH cloning uses your host SSH keys directly."
   echo ""
   echo "Examples:"
   echo "  ddev add-module token          # auto-detects the latest branch"
@@ -46,15 +44,19 @@ if [[ ! "$MODULE_NAME" =~ ^[a-z][a-z0-9_]*$ ]]; then
   exit 1
 fi
 
+cd "$DDEV_APPROOT"
+
 # Read the install path for drupal-module from Composer's installer-paths config.
-MODULE_DIR=$(composer config extra.installer-paths --json 2>/dev/null \
-  | jq -r 'to_entries[] | select(.value[] == "type:drupal-module") | .key' 2>/dev/null \
-  | sed "s/{\\\$name}/$MODULE_NAME/")
+MODULE_DIR=$(ddev exec -- bash <<'EOF' | sed "s/{\\\$name}/$MODULE_NAME/"
+composer config extra.installer-paths --json 2>/dev/null \
+  | jq -r 'to_entries[] | select(.value[] == "type:drupal-module") | .key' 2>/dev/null
+EOF
+)
 if [ -z "$MODULE_DIR" ]; then
   MODULE_DIR="modules/contrib/$MODULE_NAME"
 fi
 DRUPAL_GIT_HTTPS="https://git.drupalcode.org/project/$MODULE_NAME.git"
-DRUPAL_GIT_SSH="git@git.drupalcode.org:project/$MODULE_NAME.git"
+DRUPAL_GIT_SSH="git@git.drupal.org:project/$MODULE_NAME.git"
 
 if [ -d "$MODULE_DIR" ]; then
   if [ ! -d "$MODULE_DIR/.git" ]; then
@@ -94,18 +96,23 @@ else
     echo "Using branch: $BRANCH"
   fi
 
-  # Clone the module.
+  # Clone the module on the host.
   echo "Cloning drupal/$MODULE_NAME ($BRANCH) into $MODULE_DIR..."
   if ! git clone --branch "$BRANCH" "$REMOTE_URL" "$MODULE_DIR"; then
     echo "Error: Failed to clone drupal/$MODULE_NAME. Check that the module and branch exist."
     exit 1
   fi
+
+  # Ensure the clone is visible inside the container before composer reads it.
+  ddev mutagen sync >/dev/null 2>&1 || true
 fi
 
 # Find the dev version from the canonical Drupal Composer repo that matches
 # our branch, so the lock file records the correct dev version.
-DEV_VERSIONS=$(composer show --all "drupal/$MODULE_NAME" --format=json 2>/dev/null \
-  | jq -r '.versions[]' 2>/dev/null | grep -E '\-dev$|^dev-' || true)
+DEV_VERSIONS=$(ddev exec -- bash <<EOF | grep -E '\-dev$|^dev-' || true
+composer show --all "drupal/$MODULE_NAME" --format=json 2>/dev/null | jq -r '.versions[]' 2>/dev/null
+EOF
+)
 COMPOSER_VERSION=""
 # Try direct match: 2.0.x → 2.0.x-dev
 if echo "$DEV_VERSIONS" | grep -qx "${BRANCH}-dev"; then
@@ -130,20 +137,21 @@ fi
 # plugin detects the .git directory and skips the download, preserving
 # the checkout.
 echo "Adding path repository and requiring drupal/$MODULE_NAME..."
-composer config repositories.$MODULE_NAME path "$MODULE_DIR"
-composer require --no-interaction --update-with-all-dependencies "drupal/$MODULE_NAME:$COMPOSER_VERSION"
+ddev composer config repositories.$MODULE_NAME path "$MODULE_DIR"
+ddev composer require --no-interaction --update-with-all-dependencies "drupal/$MODULE_NAME:$COMPOSER_VERSION"
 
 # Remove the #ddev-generated marker from composer files since
-# they now contain user-specific configuration.
-sed -i '/"_comment": "#ddev-generated"/d' composer.local.json 2>/dev/null || true
-sed -i '/#ddev-generated/d' composer.local.lock 2>/dev/null || true
+# they now contain user-specific configuration. Run inside the container
+# since those files were just written there by composer.
+ddev exec -- sed -i '/"_comment": "#ddev-generated"/d' composer.local.json 2>/dev/null || true
+ddev exec -- sed -i '/#ddev-generated/d' composer.local.lock 2>/dev/null || true
 
 echo ""
 printf '\033[32m  Done! drupal/%s is ready for development in %s\033[0m\n' "$MODULE_NAME" "$MODULE_DIR"
 
 # Show require-dev dependencies with suggestions for how to install them.
 if [ -f "$MODULE_DIR/composer.json" ]; then
-  DEV_DEPS=$(jq -r '."require-dev" // {} | to_entries[] | "\(.key) \(.value)"' "$MODULE_DIR/composer.json")
+  DEV_DEPS=$(ddev exec -- jq -r '."require-dev" // {} | to_entries[] | "\(.key) \(.value)"' "$MODULE_DIR/composer.json")
   if [ -n "$DEV_DEPS" ]; then
     printf '\n'
     printf '  \033[1mDev dependencies (not installed):\033[0m\n'

--- a/commands/host/remove-module
+++ b/commands/host/remove-module
@@ -4,8 +4,6 @@
 ## Description: Remove a contrib module added with add-module
 ## Usage: remove-module <module_name>
 ## Example: "ddev remove-module token"
-## ExecRaw: true
-## MutagenSync: true
 
 set -e
 
@@ -28,22 +26,26 @@ if [[ ! "$MODULE_NAME" =~ ^[a-z][a-z0-9_]*$ ]]; then
   exit 1
 fi
 
+cd "$DDEV_APPROOT"
+
 # Read the install path for drupal-module from Composer's installer-paths config.
-MODULE_DIR=$(composer config extra.installer-paths --json 2>/dev/null \
-  | jq -r 'to_entries[] | select(.value[] == "type:drupal-module") | .key' 2>/dev/null \
-  | sed "s/{\\\$name}/$MODULE_NAME/")
+MODULE_DIR=$(ddev exec -- bash <<'EOF' | sed "s/{\\\$name}/$MODULE_NAME/"
+composer config extra.installer-paths --json 2>/dev/null \
+  | jq -r 'to_entries[] | select(.value[] == "type:drupal-module") | .key' 2>/dev/null
+EOF
+)
 if [ -z "$MODULE_DIR" ]; then
   MODULE_DIR="modules/contrib/$MODULE_NAME"
 fi
 
 # Check that the module was actually added.
-if [ ! -d "$MODULE_DIR" ] && ! composer show "drupal/$MODULE_NAME" >/dev/null 2>&1; then
+if [ ! -d "$MODULE_DIR" ] && ! ddev composer show "drupal/$MODULE_NAME" >/dev/null 2>&1; then
   echo "Error: drupal/$MODULE_NAME is not installed."
   exit 1
 fi
 
 # Check for uncommitted or untracked changes before proceeding.
-if [ -d "$MODULE_DIR/.git" ] && [ -n "$(cd "$MODULE_DIR" && git status --porcelain 2>/dev/null)" ]; then
+if [ -d "$MODULE_DIR/.git" ] && [ -n "$(git -C "$MODULE_DIR" status --porcelain 2>/dev/null)" ]; then
   echo "Error: $MODULE_DIR has uncommitted or untracked changes."
   echo "Commit or stash your changes first, or delete the directory manually."
   exit 1
@@ -51,14 +53,14 @@ fi
 
 # Remove the composer requirement.
 echo "Removing drupal/$MODULE_NAME from composer..."
-if ! composer remove --no-interaction "drupal/$MODULE_NAME"; then
+if ! ddev composer remove --no-interaction "drupal/$MODULE_NAME"; then
   echo "Error: Failed to remove drupal/$MODULE_NAME. Another package may depend on it."
   exit 1
 fi
 
 # Remove the path repository.
 echo "Removing path repository..."
-composer config --unset repositories.$MODULE_NAME || true
+ddev composer config --unset repositories.$MODULE_NAME || true
 
 # Delete the cloned directory.
 if [ -d "$MODULE_DIR" ]; then

--- a/commands/host/update-module
+++ b/commands/host/update-module
@@ -4,8 +4,6 @@
 ## Description: Update composer constraint after switching a module's branch
 ## Usage: update-module <module_name>
 ## Example: "ddev update-module token"
-## ExecRaw: true
-## MutagenSync: true
 
 set -e
 
@@ -30,10 +28,14 @@ if [[ ! "$MODULE_NAME" =~ ^[a-z][a-z0-9_]*$ ]]; then
   exit 1
 fi
 
+cd "$DDEV_APPROOT"
+
 # Read the install path for drupal-module from Composer's installer-paths config.
-MODULE_DIR=$(composer config extra.installer-paths --json 2>/dev/null \
-  | jq -r 'to_entries[] | select(.value[] == "type:drupal-module") | .key' 2>/dev/null \
-  | sed "s/{\\\$name}/$MODULE_NAME/")
+MODULE_DIR=$(ddev exec -- bash <<'EOF' | sed "s/{\\\$name}/$MODULE_NAME/"
+composer config extra.installer-paths --json 2>/dev/null \
+  | jq -r 'to_entries[] | select(.value[] == "type:drupal-module") | .key' 2>/dev/null
+EOF
+)
 if [ -z "$MODULE_DIR" ]; then
   MODULE_DIR="modules/contrib/$MODULE_NAME"
 fi
@@ -45,7 +47,7 @@ if [ ! -d "$MODULE_DIR/.git" ]; then
 fi
 
 # Read the current branch.
-BRANCH=$(cd "$MODULE_DIR" && git symbolic-ref --short HEAD 2>/dev/null)
+BRANCH=$(git -C "$MODULE_DIR" symbolic-ref --short HEAD 2>/dev/null)
 if [ -z "$BRANCH" ]; then
   echo "Error: $MODULE_DIR is in a detached HEAD state."
   echo "Check out a branch first: cd $MODULE_DIR && git checkout <branch>"
@@ -54,8 +56,10 @@ fi
 
 # Find the dev version from the canonical Drupal Composer repo that matches
 # the current branch.
-DEV_VERSIONS=$(composer show --all "drupal/$MODULE_NAME" --format=json 2>/dev/null \
-  | jq -r '.versions[]' 2>/dev/null | grep -E '\-dev$|^dev-' || true)
+DEV_VERSIONS=$(ddev exec -- bash <<EOF | grep -E '\-dev$|^dev-' || true
+composer show --all "drupal/$MODULE_NAME" --format=json 2>/dev/null | jq -r '.versions[]' 2>/dev/null
+EOF
+)
 COMPOSER_VERSION=""
 # Try direct match: 2.0.x → 2.0.x-dev
 if echo "$DEV_VERSIONS" | grep -qx "${BRANCH}-dev"; then
@@ -77,7 +81,7 @@ if [ -z "$COMPOSER_VERSION" ]; then
 fi
 
 echo "Updating drupal/$MODULE_NAME to $COMPOSER_VERSION (branch: $BRANCH)..."
-composer require --no-interaction --update-with-all-dependencies "drupal/$MODULE_NAME:$COMPOSER_VERSION"
+ddev composer require --no-interaction --update-with-all-dependencies "drupal/$MODULE_NAME:$COMPOSER_VERSION"
 
 echo ""
 printf '\033[32m  Done! drupal/%s updated to %s\033[0m\n' "$MODULE_NAME" "$COMPOSER_VERSION"

--- a/install.yaml
+++ b/install.yaml
@@ -9,9 +9,9 @@ project_files:
   - drupal-dev/gitignore
   - drupal-dev/composer-plugin
   - commands/host/phpunit
-  - commands/web/add-module
-  - commands/web/update-module
-  - commands/web/remove-module
+  - commands/host/add-module
+  - commands/host/update-module
+  - commands/host/remove-module
   - docker-compose.drupal-dev-selenium.yaml
   - config.drupal-dev.yaml
 
@@ -21,6 +21,16 @@ post_install_actions:
   - "[ -f ../composer.local.json ] || cp drupal-dev/composer.local.json ../composer.local.json"
   - "! [ -f ../.envrc ] || grep -q '#ddev-generated' ../.envrc && cp drupal-dev/envrc ../.envrc"
   - "! [ -f ../.gitignore ] || grep -q '#ddev-generated' ../.gitignore && cp drupal-dev/gitignore ../.gitignore"
+  # Clean up web commands from a previous install now that these commands
+  # have moved to commands/host/. Only remove files still marked as generated.
+  - |
+    for cmd in add-module remove-module update-module; do
+      f="commands/web/$cmd"
+      if [ -f "$f" ] && grep -q '#ddev-generated' "$f"; then
+        rm -f "$f"
+      fi
+    done
+    rmdir commands/web 2>/dev/null || true
   # Create test output directory
   - mkdir -p ../test_output
   # User-friendly post-install message

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -172,13 +172,11 @@ teardown() {
   assert_success
 
   # Rejects a non-git directory at the install path
-  run ddev exec -- mkdir -p modules/contrib/fakemodule
-  assert_success
+  mkdir -p "${TESTDIR}/modules/contrib/fakemodule"
   run ddev add-module --https fakemodule
   assert_failure
   assert_output --partial "not a git checkout"
-  run ddev exec -- rmdir modules/contrib/fakemodule
-  assert_success
+  rmdir "${TESTDIR}/modules/contrib/fakemodule"
 
   # remove-module aborts when there are uncommitted changes
   echo 'dirty' > "${TESTDIR}/modules/contrib/token/dirty.txt"
@@ -269,7 +267,7 @@ teardown() {
   assert_file_not_exists "${TESTDIR}/.ddev/drupal-dev"
   assert_file_not_exists "${TESTDIR}/.ddev/config.drupal-dev.yaml"
   assert_file_not_exists "${TESTDIR}/.ddev/commands/host/phpunit"
-  assert_file_not_exists "${TESTDIR}/.ddev/commands/web/add-module"
-  assert_file_not_exists "${TESTDIR}/.ddev/commands/web/remove-module"
-  assert_file_not_exists "${TESTDIR}/.ddev/commands/web/update-module"
+  assert_file_not_exists "${TESTDIR}/.ddev/commands/host/add-module"
+  assert_file_not_exists "${TESTDIR}/.ddev/commands/host/remove-module"
+  assert_file_not_exists "${TESTDIR}/.ddev/commands/host/update-module"
 }


### PR DESCRIPTION
- Move add-module/remove-module/update-module from commands/web/ to commands/host/ so git clones run on the host and use your local SSH config directly; no more `ddev auth ssh` needed to forward keys into the container.
- Switch the SSH clone URL back to `git.drupal.org`: port 22 on `git.drupalcode.org` is blocked on some networks, while `git.drupal.org` is reachable and maps to the same GitLab backend.
- `install.yaml` removes stale `commands/web/*-module` files from prior installs (only when still marked `#ddev-generated`).

Fixes #9.