### PR TITLE
Remove setAccessible() from Plugin.php

### DIFF
--- a/drupal-dev/composer-plugin/src/Plugin.php
+++ b/drupal-dev/composer-plugin/src/Plugin.php
@@ -108,7 +108,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface
                 continue;
             }
             $property = $reflection->getProperty($name);
-            $property->setAccessible(true);
             $property->setValue($root, $value);
         }
     }


### PR DESCRIPTION
## The Issue

- Fixes #13 

<!-- Provide a brief description of the issue. -->

When running for example a `ddev composer update`you run into: 

```
Deprecation Notice: Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/.ddev/drupal-dev/composer-plugin/src/Plugin.php:111
```

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->
I've simply removed the line after per deprecation notice it has not effect since PHP 8.1 . I 've also checked for similar cases in the drupal issue queue and in for example https://www.drupal.org/project/metatag/issues/3563261 the line was also simply striked.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/amateescu/ddev-drupal-dev/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
