### PR TITLE
Increase the version constraint for the installer to v1.25.0

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,6 +1,6 @@
 name: drupal-dev
 
-ddev_version_constraint: '>= v1.24.6'
+ddev_version_constraint: '>= v1.25.0'
 
 project_files:
   - drupal-dev/composer.local.json


### PR DESCRIPTION
## The Issue

- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER

<!-- Provide a brief description of the issue. -->
At the moment `ddev_version_constraint` is at v1.24.6, problem is the `drupal12` project type that is used in the readme got introduced in DDEV 1.25.0 https://github.com/ddev/ddev/releases/tag/v1.25.0 (see the features section)

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->
Increase the minimum version requirement to v1.25.0
## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/amateescu/ddev-drupal-dev/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
