### PR TITLE
Recommend `drupal` project type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Clone Drupal core and configure DDEV to use it as the project root:
 ```bash
 git clone https://git.drupalcode.org/project/drupal.git drupal-dev
 cd drupal-dev
-ddev config --project-type=drupal12
+ddev config --project-type=drupal
 ddev start
 ```
 


### PR DESCRIPTION
## The Issue

Recommended project type uses hardcoded Drupal version

## How This PR Solves The Issue

As per https://github.com/ddev/ddev/blob/v1.25.2/pkg/nodeps/values.go#L103-L104 the alias `drupal` means "most recent Drupal version".

## Manual Testing Instructions

It's a docs only change. Can test by following the new instructions.

## Automated Testing Overview

As above

## Release/Deployment Notes

N/A