### PR TITLE
Update SIMPLETEST_BASE_URL to use DDEV_PRIMARY_URL

### DIFF
--- a/config.drupal-dev.yaml
+++ b/config.drupal-dev.yaml
@@ -3,7 +3,7 @@ web_environment:
   - COMPOSER=composer.local.json
   # Test environment
   - SIMPLETEST_DB=mysql://db:db@db/db
-  - SIMPLETEST_BASE_URL=http://web
+  - SIMPLETEST_BASE_URL=${DDEV_PRIMARY_URL}
   - BROWSERTEST_OUTPUT_DIRECTORY=/var/www/html/${DDEV_DOCROOT}/test_output
   - BROWSERTEST_OUTPUT_BASE_URL=${DDEV_PRIMARY_URL}
   - SYMFONY_DEPRECATIONS_HELPER=ignoreFile=/var/www/html/${DDEV_DOCROOT}/core/.deprecation-ignore.txt


### PR DESCRIPTION
## The Issue

When using xdebug in a test the test itself uses the ddev hostname as the server name, but the SUT uses `web`. This means we need two sets of path mappings. If you have multiple projects open and listening for connections they might both have a `web` server and conflict.

## How This PR Solves The Issue

Just use the ddev hostname instead of hardcoding to http://web

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/amateescu/ddev-drupal-dev/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
