### PR TITLE
Run bats tests in parallel on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install GNU parallel for bats --jobs
+        run: sudo apt-get install -qq -y parallel
+
       - uses: ddev/github-action-add-on-test@v2
         with:
           ddev_version: ${{ matrix.ddev_version }}
@@ -43,3 +46,4 @@ jobs:
           debug_enabled: ${{ github.event.inputs.debug_enabled }}
           addon_repository: ${{ env.GITHUB_REPOSITORY }}
           addon_ref: ${{ env.GITHUB_REF }}
+          test_command: ${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'bats --jobs 4 tests' || 'bats --jobs 4 tests --filter-tags !release' }}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -7,6 +7,8 @@
 # For local tests, install bats-core, bats-assert, bats-file, bats-support
 # And run this in the add-on root directory:
 #   bats ./tests/test.bats
+# To run tests in parallel (much faster, requires GNU parallel):
+#   bats --jobs 4 ./tests/test.bats
 # To exclude release tests:
 #   bats ./tests/test.bats --filter-tags '!release'
 # For debugging:
@@ -24,7 +26,7 @@ setup() {
   bats_load_library bats-support
 
   export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
-  export PROJNAME="test-$(basename "${GITHUB_REPO}")"
+  export PROJNAME="test-$(basename "${GITHUB_REPO}")-${BATS_TEST_NUMBER:-0}"
   mkdir -p "${HOME}/tmp"
   export TESTDIR="$(mktemp -d "${HOME}/tmp/${PROJNAME}.XXXXXX")"
   export DDEV_NONINTERACTIVE=true
@@ -35,7 +37,9 @@ setup() {
   git clone --depth=1 --branch 11.x https://git.drupalcode.org/project/drupal.git "${TESTDIR}"
   cd "${TESTDIR}"
 
-  run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site --project-type=drupal11 --php-version=8.3
+  # Omit ddev-ssh-agent so parallel 'ddev start' calls don't race on the
+  # shared container name; tests use HTTPS for any git operations.
+  run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site --project-type=drupal11 --php-version=8.3 --omit-containers=ddev-ssh-agent
   assert_success
   run ddev start -y
   assert_success


### PR DESCRIPTION
- Install GNU parallel (`bats --jobs` requires it).
- Pass `--jobs 4` via the test action's `test_command`.
- Suffix `PROJNAME` with `BATS_TEST_NUMBER` so concurrent DDEV projects don't collide.