### PR TITLE
ci(test): add `COMPOSER_NO_SECURITY_BLOCKING=1`

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -35,6 +35,9 @@ setup() {
   git clone --depth=1 --branch 11.x https://git.drupalcode.org/project/drupal.git "${TESTDIR}"
   cd "${TESTDIR}"
 
+  # Ignore Composer security advisories in tests
+  export COMPOSER_NO_SECURITY_BLOCKING=1
+
   run ddev config --project-name="${PROJNAME}" --project-tld=ddev.site --project-type=drupal11 --php-version=8.3
   assert_success
   run ddev start -y


### PR DESCRIPTION
## The Issue

https://github.com/amateescu/ddev-drupal-dev/actions/runs/26154363262/job/76929735640

```
#   No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.
#   > Drupal\Composer\Composer::ensureComposerVersion
#   Loading composer repositories with package information
#   Core lock pinning active. If solve fails, try setting extra.drupal-dev.pin-core-lock to false to isolate the cause.
#   Updating dependencies
#   Your requirements could not be resolved to an installable set of packages.
#
#     Problem 1
#       - Root composer.json requires drupal/core 11.9999999.9999999.9999999-dev -> satisfiable by drupal/core[11.x-dev].
#       - drupal/core 11.x-dev requires twig/twig ^3.21.0 -> found twig/twig[v3.21.0, ..., 3.x-dev] but these were not loaded, because they are affected by security advisories ("PKSA-5k7f-wvjj-jrgw", "PKSA-sjvz-tbbr-vwth", "PKSA-h8hf-ytnd-5t9q", "PKSA-wwb1-81rc-pd65", "PKSA-hgmw-wn4d-hpcy", "PKSA-kvv6-36cr-fkzb", "PKSA-n14z-jjjg-g8vd", "PKSA-3mcc-k66d-pydb", "PKSA-gw7n-z4yx-7xjt", "PKSA-dpx1-78wg-1kqs", "PKSA-21g2-dzjv-sky5"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

## How This PR Solves The Issue

It's always annoying to see temporary problems like this in tests.

`ddev composer` doesn't ignore security advisories (just like `composer`), but it respects the value of `COMPOSER_NO_SECURITY_BLOCKING=1`, which can be passed inside.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/amateescu/ddev-drupal-dev/tarball/refs/pull/22/head
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
